### PR TITLE
Fix order strings to work with puppetlabs-concat 

### DIFF
--- a/manifests/appdefaults.pp
+++ b/manifests/appdefaults.pp
@@ -29,7 +29,7 @@ define mit_krb5::appdefaults(
   })
   concat::fragment { "mit_krb5::appdefaults::${title}":
     target  => $mit_krb5::krb5_conf_path,
-    order   => "51appdefault::${title}",
+    order   => "51appdefault-${title}",
     content => template('mit_krb5/appdefaults.erb'),
   }
 }

--- a/manifests/domain_realm.pp
+++ b/manifests/domain_realm.pp
@@ -48,7 +48,7 @@ define mit_krb5::domain_realm(
     })
     concat::fragment { "mit_krb5::domain_realm::${title}":
       target  => $mit_krb5::krb5_conf_path,
-      order   => "21realm::${realm}::${title}",
+      order   => "21realm-${realm}-${title}",
       content => template('mit_krb5/domain_realm.erb'),
     }
   }

--- a/manifests/realm.pp
+++ b/manifests/realm.pp
@@ -109,7 +109,7 @@ define mit_krb5::realm(
   })
   concat::fragment { "mit_krb5::realm::${title}":
     target  => $mit_krb5::krb5_conf_path,
-    order   => "11realm::${title}",
+    order   => "11realm-${title}",
     content => template('mit_krb5/realm.erb'),
   }
 }


### PR DESCRIPTION
avoid Error 400 on SERVER: Order cannot contain '/', ':', or '
'.  

":" is not a valid concat::fragment order string.