### PR TITLE
Updated metadata.json to adhere to proper syntax

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -228,8 +228,9 @@ class mit_krb5(
   $krb5_conf_owner          = 'root',
   $krb5_conf_group          = 'root',
   $krb5_conf_mode           = '0444',
-  $alter_etc_services       = false
-) {
+  $alter_etc_services       = false,
+  $includedir               = $mit_krb5::params::includedir,
+) inherits mit_krb5::params {
   # SECTION: Parameter validation {
   validate_string(
     $default_realm,
@@ -266,7 +267,7 @@ class mit_krb5(
   anchor { 'mit_krb5::begin': }
 
   class { '::mit_krb5::install': }
-  
+
   if ($alter_etc_services == true) {
     class { '::mit_krb5::config::etc_services':
       require => Class['::mit_krb5::install']
@@ -274,10 +275,17 @@ class mit_krb5(
   }
 
   concat { $krb5_conf_path:
-    owner  => $krb5_conf_owner,
-    group  => $krb5_conf_group,
-    mode   => $krb5_conf_mode,
+    owner => $krb5_conf_owner,
+    group => $krb5_conf_group,
+    mode  => $krb5_conf_mode,
   }
+
+  concat::fragment {'mit_krb5::header':
+    target  => $krb5_conf_path,
+    order   => '00',
+    content => template('mit_krb5/header.erb'),
+  }
+
   concat::fragment { 'mit_krb5::libdefaults':
     target  => $krb5_conf_path,
     order   => '01libdefaults',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,18 @@
+# Class: mit_krb5::params
+#
+class mit_krb5::params {
+
+  if $::operatingsystemmajrelease {
+    $os_maj_release = $::operatingsystemmajrelease
+  } else {
+    $os_versions    = split($::operatingsystemrelease, '[.]')
+    $os_maj_release = $os_versions[0]
+  }
+
+  case $os_maj_release {
+    '7' : {
+      $includedir = ['/etc/krb5.conf.d/', ]
+    }
+    default: { $includedir = [] }
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ccin2p3-mit_krb5",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "source": "https://github.com/ccin2p3/puppet-mit_krb5.git",
   "author": "Patrick Mooney <patrick.f.mooney@gmail.com>",
   "license": "Apache-2.0",
@@ -9,8 +9,8 @@
   "project_page": "https://github.com/ccin2p3/puppet-mit_krb5",
   "issues_url": "https://github.com/ccin2p3/puppet-mit_krb5/issues",
   "dependencies": [
-    { "name": "puppetlabs/concat", "version_requirement": ">= 1.0.x < 3.0.0" }, 
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 3.x < 4.0.0" }
+    { "name": "puppetlabs/concat", "version_requirement": ">= 1.0 <= 4.2.0" }, 
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 3.0 <= 4.25.0" }
   ],
   "tags": [
     "kerberos",

--- a/templates/header.erb
+++ b/templates/header.erb
@@ -1,0 +1,7 @@
+# This file managed by Puppet.  Do not edit!
+<%- if !@includedir.empty? -%>
+# Configuration snippets may be placed in this directory as well
+<% @includedir.each do |dir| -%>
+includedir <%= dir %>
+<% end %>
+<% end -%>


### PR DESCRIPTION
"X"s are not allowed when using =, < or >.  

Also updated to reflect current puppetlabs-stdlib and puppetlabs-concat versions (which I've tested in my environment).