### PR TITLE
Add default_ccache_name and pkinit_anchors params.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Top-level class that installs MIT Kerberos and controls krb5.conf file.  Class p
 - `default_keytab_name`
 - `default_tgs_enctypes`
 - `default_tkt_enctypes`
+- `default_ccache_name`
 - `permitted_enctypes`
 - `allow_weak_crypto`
 - `clockskew`
@@ -177,6 +178,7 @@ Realm name is specified by resource title
 - `v4_realm`
 - `auth_to_local_names`
 - `auth_to_local`
+- `pkinit_anchors`
 
 ## mit\_krb5::logging
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,9 @@
 #   This relation identifies the supported list of session key encryption types
 #   that should be requested by the client. (Required type: array)
 #
+# [*default_ccache_name*]
+#   This relation allows you to set a default credential cache name
+#
 # [*permitted_enctypes*]
 #   This relation identifies the permitted list of session key encryption
 #   types. (Required type: array)
@@ -198,6 +201,7 @@ class mit_krb5(
   $default_keytab_name      = '',
   $default_tgs_enctypes     = [],
   $default_tkt_enctypes     = [],
+  $default_ccache_name      = '',
   $permitted_enctypes       = [],
   $allow_weak_crypto        = '',
   $clockskew                = '',
@@ -233,6 +237,7 @@ class mit_krb5(
   # SECTION: Parameter validation {
   validate_string(
     $default_realm,
+    $default_ccache_name,
     $default_keytab_name,
     $clockskew,
     $k5login_directory,

--- a/manifests/realm.pp
+++ b/manifests/realm.pp
@@ -69,6 +69,9 @@
 #       has more than one component or is not in the default realm, this rule
 #       is not applicable and the conversion will fail.
 #
+# [*pkinit_anchors*]
+#   This relation allows you set the path of a certificate authority file.
+#
 # === Examples
 #
 #  mit_krb5::realm { 'TEST.COM':
@@ -98,6 +101,7 @@ define mit_krb5::realm(
   $auth_to_local       = '',
   $kpasswd_server      = '',
   $v4_realm_convert    = '',
+  $pkinit_anchors      = '',
 ) {
 
   include ::mit_krb5

--- a/templates/libdefaults.erb
+++ b/templates/libdefaults.erb
@@ -1,6 +1,7 @@
 <% fields = [
   'default_realm',
   'default_keytab_name',
+  'default_ccache_name',
   'default_tgs_enctypes',
   'default_tkt_enctypes',
   'permitted_enctypes',

--- a/templates/realm.erb
+++ b/templates/realm.erb
@@ -9,7 +9,7 @@
     'admin_server',
     'kdc',
     'v4_realm_convert',
-
+    'pkinit_anchors',
 ]
 array_fields = ['kdc', 'admin_server']
 output = []


### PR DESCRIPTION
This ports 56030dd6e4662b09559fe6a684eaf6f7e56ba37d from pfmooney/puppet-mit_krb5 over. Needed to set e.g. the new default credential collection keyring used in RHEL 7. 