### PR TITLE
Implement dbmodules section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
     - [mit\_krb5::logging](#mit_krb5logging)
     - [mit\_krb5::domain\_realm](#mit_krb5domain_realm)
     - [mit\_krb5::appdefaults](#mit_krb5appdefaults)
+    - [mit\_krb5::dbmodules](#mit_krb5dbmodules)
 5. [Limitations](#limitations)
 6. [License](#license)
 7. [Development](#development)
@@ -255,6 +256,28 @@ could be obtained with
 }
 ```
 
+## mit\_krb5::dbmodules
+
+Class to configure \[dbmodules\] section
+
+### Parameters from dbmodules section
+
+- db\_module\_dir
+
+Per realm:
+
+- database\_name
+- db\_library
+- disable\_last\_success
+- disable\_lockout
+- ldap\_cert\_path
+- ldap\_conns\_per\_server
+- ldap\_kadmind\_dn
+- ldap\_kdc\_dn
+- ldap\_kerberos\_container\_dn
+- ldap\_servers (arrays allowed)
+- ldap\_service\_password\_file
+
 # Limitations
 
 Configuration sections other than those listed above are not yet supported.
@@ -262,7 +285,6 @@ This includes:
 
 - `capaths`
 - `dbdefaults`
-- `dbmodules`
 - `login`
 - `plugins`
 

--- a/manifests/dbmodules.pp
+++ b/manifests/dbmodules.pp
@@ -2,15 +2,118 @@
 #
 # Configure dbmodules section of krb5.conf
 #
+# === Parameters
+#
+# [*realm*]
+#   Realm this configuration applied to. Defaults to $title.
+#
+# [*database_name*]
+#   This DB2-specific tag indicates the location of the database in the
+#   filesystem. The default is LOCALSTATEDIR/krb5kdc/principal.
+#
+# [*db_library*]
+#   This tag indicates the name of the loadable database module. The
+#   value should be db2 for the DB2 module and kldap for the LDAP module.
+#
+# [*disable_last_success*]
+#   If set to true, suppresses KDC updates to the “Last successful
+#   authentication” field of principal entries requiring preauthentication.
+#   Setting this flag may improve performance. (Principal entries which do not
+#   require preauthentication never update the “Last successful authentication”
+#   field.). First introduced in release 1.9.
+#
+# [*disable_lockout*]
+#   If set to true, suppresses KDC updates to the “Last failed authentication”
+#   and “Failed password attempts” fields of principal entries requiring
+#   preauthentication. Setting this flag may improve performance, but also
+#   disables account lockout. First introduced in release 1.9.
+#
+# [*ldap_cert_path*]
+#   Path to the Network Security Services (NSS) trusted database for an SSL connection. 
+#   This is a required parameter when using the LDAP KDB plug-in.
+#
+# [*ldap_conns_per_server*]
+#   This LDAP-specific tag indicates the number of connections to be
+#   maintained per LDAP server.
+#
+# [*ldap_kadmind_dn*]
+#   This LDAP-specific tag indicates the default bind DN for the kadmind
+#   daemon. kadmind does a login to the directory as this object. This object
+#   should have the rights to read and write the Kerberos data in the LDAP
+#   database.
+#
+# [*ldap_kdc_dn*]
+#   This LDAP-specific tag indicates the default bind DN for the krb5kdc
+#   daemon. The KDC does a login to the directory as this object. This object
+#   should have the rights to read the Kerberos data in the LDAP database, and
+#   to write data unless disable_lockout and disable_last_success are true.
+#
+# [*ldap_kerberos_container_dn*]
+#   This LDAP-specific tag indicates the DN of the container object where the
+#   realm objects will be located.
+#
+# [*ldap_servers*]
+#   This LDAP-specific tag indicates the list of LDAP servers that the
+#   Kerberos servers can connect to. The LDAP server is specified by a LDAP
+#   URI. It is recommended to use ldapi: or ldaps: URLs to connect to the LDAP
+#   server.
+#
+# [*ldap_service_password_file*]
+#   This LDAP-specific tag indicates the file containing the stashed passwords
+#   (created by kdb5_ldap_util stashsrvpw) for the ldap_kadmind_dn and
+#   ldap_kdc_dn objects. This file must be kept secure.
+#
+# === Examples
+#
+#  mit_krb5::dbmodules { 'TEST.COM':
+#    db_library => 'mylib.so'
+#  }
+#
+#  Results in:
+#  [dbmodules]
+#      db_library = mylib.so
+#
 # === Authors
 #
 # Patrick Mooney <patrick.f.mooney@gmail.com>
+# Modestas Vainius <modestas@vainius.eu>
 #
 # === Copyright
 #
 # Copyright 2013 Patrick Mooney.
-# Copyright (c) IN2P3 Computing Centre, IN2P3, CNRS
+# Copyright 2016 Modestas Vainius.
 #
-class mit_krb5::dbmodules {
-  fail('PLACEHOLDER: Not yet implemented')
+define mit_krb5::dbmodules(
+  $realm                      = $title,
+  $database_name              = '',
+  $db_library                 = '',
+  $disable_last_success       = '',
+  $disable_lockout            = '',
+  $ldap_cert_path             = '',
+  $ldap_conns_per_server      = '',
+  $ldap_kadmind_dn            = '',
+  $ldap_kdc_dn                = '',
+  $ldap_kerberos_container_dn = '',
+  $ldap_servers               = '',
+  $ldap_service_password_file = '',
+) {
+  include mit_krb5
+  validate_string($realm)
+  ensure_resource('concat::fragment', 'mit_krb5::dbmodules_header', {
+    target  => $mit_krb5::krb5_conf_path,
+    order   => '30dbmodules_header',
+    content => "[dbmodules]\n",
+  })
+  if (! empty($mit_krb5::db_module_dir)) {
+    ensure_resource('concat::fragment', 'mit_krb5::dbmodules_db_module_dir', {
+      target  => $mit_krb5::krb5_conf_path,
+      order   => '31dbmodules_db_module_dir',
+      content => "    db_module_dir = ${mit_krb5::db_module_dir}\n",
+    })
+  }
+  concat::fragment { "mit_krb5::dbmodules::${realm}":
+    target  => $mit_krb5::krb5_conf_path,
+    order   => "32dbmodules_${realm}",
+    content => template('mit_krb5/dbmodules.erb'),
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,6 +175,10 @@
 #   default value is the "krb5/plugins" subdirectory of the krb5 library
 #   directory.
 #
+# [*db_module_dir*]
+#   This tag controls where the plugin system looks for database modules. The
+#   value should be an absolute path.
+#
 # [*krb5_conf_path*]
 #   Path to krb5.conf file.  (Default: /etc/krb5.conf)
 #
@@ -235,6 +239,7 @@ class mit_krb5(
   $proxiable                = '',
   $rdns                     = '',
   $plugin_base_dir          = '',
+  $db_module_dir            = '',
   $krb5_conf_path           = '/etc/krb5.conf',
   $krb5_conf_owner          = 'root',
   $krb5_conf_group          = 'root',
@@ -259,6 +264,7 @@ class mit_krb5(
     $ticket_lifetime,
     $renew_lifetime,
     $plugin_base_dir,
+    $db_module_dir,
     $krb5_conf_path,
     $krb5_conf_owner,
     $krb5_conf_group,

--- a/templates/dbmodules.erb
+++ b/templates/dbmodules.erb
@@ -1,0 +1,32 @@
+<% fields = [
+    'database_name',
+    'db_library',
+    'disable_last_success',
+    'disable_lockout',
+    'ldap_cert_path',
+    'ldap_conns_per_server',
+    'ldap_kadmind_dn',
+    'ldap_kdc_dn',
+    'ldap_kerberos_container_dn',
+    'ldap_servers',
+    'ldap_service_password_file',
+]
+array_fields = ['ldap_servers']
+output = []
+scope_hash = scope.to_hash
+fields.each do |k|
+  if scope_hash.include?(k)
+    value = scope_hash[k]
+    if array_fields.include? k and value.respond_to?('each')
+      # Allow multiple servers via array
+      value.flatten! if value.respond_to?('flatten')
+      output.push("#{k} = #{value.join(" ")}")
+    elsif not value.empty?
+      output.push("#{k} = #{value}")
+    end
+  end
+end
+-%>
+    <%= @realm %> = {
+        <%= output.join("\n        ") %>
+    }

--- a/templates/domain_realm.erb
+++ b/templates/domain_realm.erb
@@ -1,3 +1,3 @@
 <% @domains.each do |domain| -%>
     <%= domain %> = <%= @realm %>
-<% end -%>
+<% end %>


### PR DESCRIPTION
This ports 45222fe from [modax/puppet-mit_krb5](url) over. Including some minor changes to ldap_cert_path.