### PR TITLE
Implement top-level include, includedir, module directives.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,14 @@ krb5.conf.
 ## mit\_krb5
 
 Top-level class that installs MIT Kerberos and controls krb5.conf file.  Class
-parameters are used to define contents of \[libdefaults\] section.
+parameters are used to define top-level directives and  contents of
+\[libdefaults\] section.
+
+### Top-level directives
+
+- include - (arrays allowed)
+- includedir - (arrays allowed)
+- module - (arrays allowed)
 
 ### Parameters from libdefaults section
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,6 +175,25 @@
 #   default value is the "krb5/plugins" subdirectory of the krb5 library
 #   directory.
 #
+# [*include*]
+#   The named file should be an absolute path, must exist and must be readable.
+#   Included profile files are syntactically independent of their parents, so
+#   each included file must begin with a section header.
+#
+# [*includedir*]
+#   The named directory should be an absolute path, must exist and must be
+#   readable.  Including a directory includes all files within the directory
+#   whose names consist solely of alphanumeric characters, dashes, or
+#   underscores. Included profile files are syntactically independent of their
+#   parents, so each included file must begin with a section header.
+#
+# [*module*]
+#   *MODULEPATH:RESIDUAL*
+#   MODULEPATH may be relative to the library path of the krb5 installation, or
+#   it may be an absolute path. RESIDUAL is provided to the module at
+#   initialization time. If krb5.conf uses a module directive, kdc.conf should
+#   also use one if it exists.
+#
 # [*krb5_conf_path*]
 #   Path to krb5.conf file.  (Default: /etc/krb5.conf)
 #
@@ -235,6 +254,9 @@ class mit_krb5(
   $proxiable                = '',
   $rdns                     = '',
   $plugin_base_dir          = '',
+  $include                  = '',
+  $includedir               = '',
+  $module                   = '',
   $krb5_conf_path           = '/etc/krb5.conf',
   $krb5_conf_owner          = 'root',
   $krb5_conf_group          = 'root',
@@ -289,6 +311,11 @@ class mit_krb5(
     owner => $krb5_conf_owner,
     group => $krb5_conf_group,
     mode  => $krb5_conf_mode,
+  }
+  concat::fragment { 'mit_krb5::header':
+    target  => $krb5_conf_path,
+    order   => '00header',
+    content => template('mit_krb5/header.erb'),
   }
   concat::fragment { 'mit_krb5::libdefaults':
     target  => $krb5_conf_path,

--- a/templates/header.erb
+++ b/templates/header.erb
@@ -1,0 +1,27 @@
+<% fields = [
+  'include',
+  'includedir',
+  'module',
+]
+array_fields = ['include', 'includedir', 'module']
+output = []
+scope_hash = scope.to_hash
+fields.each do |k|
+  if scope_hash.include?(k)
+    value = scope_hash[k]
+    if array_fields.include? k and value.respond_to?('each')
+      # Allow multiple servers via array
+      value.flatten! if value.respond_to?('flatten')
+      value.each do |v|
+        output.push("#{k} #{v}")
+      end
+    elsif not value.empty?
+      output.push("#{k} #{value}")
+    end
+  end
+end
+-%>
+<% if not output.empty? -%>
+<%= output.join("\n") %>
+
+<% end -%>


### PR DESCRIPTION
This ports 1a619dd from modax/puppet-mit_krb5 over. 