### PR TITLE
Support kpasswd_server and master_kdc params for [realms].

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Realm name is specified by resource title
 ### Parameters from realm section
 
 - `kdc` - (arrays allowed)
+- `kpasswd_server`
+- `master_kdc`
 - `admin_server` - (arrays allowed)
 - `database_module`
 - `default_domain`

--- a/manifests/realm.pp
+++ b/manifests/realm.pp
@@ -10,6 +10,18 @@
 #   the hostname.  This tag should generally be used only if the realm
 #   administrator has not made the information available through DNS.
 #
+# [*kpasswd_server*]
+#    Points to the server where all the password changes are performed. If
+#    there is no such entry, the port 464 on the admin_server host will be
+#    tried.
+#
+# [*master_kdc*]
+#   Identifies the master KDC(s). Currently, this tag is used in only one case:
+#   If an attempt to get credentials fails because of an invalid password, the
+#   client software will attempt to contact the master KDC, in case the user’s
+#   password has just been changed, and the updated database has not been
+#   propagated to the slave servers yet.
+#
 # [*admin_server*]
 #   This relation identifies the host where the administration server is
 #   running.  Typically this is the Master Kerberos server.
@@ -92,6 +104,7 @@
 #
 define mit_krb5::realm(
   $kdc                 = '',
+  $master_kdc          = '',
   $admin_server        = '',
   $database_module     = '',
   $default_domain      = '',

--- a/templates/realm.erb
+++ b/templates/realm.erb
@@ -8,6 +8,7 @@
     'kpasswd_server',
     'admin_server',
     'kdc',
+    'master_kdc',
     'v4_realm_convert',
     'pkinit_anchors',
 ]


### PR DESCRIPTION
This ports 58b32ef from modax/puppet-mit_krb5. Including some minor changes.