### PR TITLE
realm: Add parameter to rotate kdcs and admin servers arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ Realm name is specified by resource title
 - `auth_to_local`
 - `pkinit_anchors`
 - `pkinit_pool`
+- `rotate_servers` - Whether to apply a random rotation to the list of KDCs and
+  admin servers so that the server usage is more evenly distributed.  (Default: `false`)
 
 ## mit\_krb5::logging
 

--- a/manifests/realm.pp
+++ b/manifests/realm.pp
@@ -88,6 +88,10 @@
 #   Specifies the location of intermediate certificates which may be used by the
 #   client to complete the trust chain between a KDC certificate and a trusted anchor. 
 #
+# [*rotate_servers*]
+#   Whether to apply a random rotation to the list of KDCs and admin servers so
+#   that the server usage is more evenly distributed.  (Default: `false`)
+#
 # === Examples
 #
 #  mit_krb5::realm { 'TEST.COM':
@@ -107,19 +111,20 @@
 # Copyright (c) IN2P3 Computing Centre, IN2P3, CNRS
 #
 define mit_krb5::realm(
-  $kdc                 = '',
-  $master_kdc          = '',
-  $admin_server        = '',
-  $database_module     = '',
-  $default_domain      = '',
-  $v4_instance_convert = '',
-  $v4_realm            = '',
-  $auth_to_local_names = '',
-  $auth_to_local       = '',
-  $kpasswd_server      = '',
-  $v4_realm_convert    = '',
-  $pkinit_anchors      = '',
-  $pkinit_pool         = '',
+  $kdc                    = '',
+  $master_kdc             = '',
+  $admin_server           = '',
+  $database_module        = '',
+  $default_domain         = '',
+  $v4_instance_convert    = '',
+  $v4_realm               = '',
+  $auth_to_local_names    = '',
+  $auth_to_local          = '',
+  $kpasswd_server         = '',
+  $v4_realm_convert       = '',
+  $pkinit_anchors         = '',
+  $pkinit_pool            = '',
+  Boolean $rotate_servers = false,
 ) {
 
   include ::mit_krb5

--- a/templates/realm.erb
+++ b/templates/realm.erb
@@ -23,6 +23,7 @@ fields.each do |k|
         if array_fields.include? k and value.respond_to?('each')
       # Allow multiple servers via array
         value.flatten! if value.respond_to?('flatten')
+        value = scope.call_function('fqdn_rotate', [value]) if scope_hash['rotate_servers']
         value.each do |v|
             output.push("#{k} = #{v}")
         end


### PR DESCRIPTION
We have observed that clients prefer to talk to KDCs in the order
they're listed in `/etc/krb5.conf`.  To more evenly distribute the load
across a list of servers, add a new parameter, `rotate_servers`,
disabled by default, which, when enabled, uses the `fqdn_rotate` Puppet
function to idempotently "reorder" the list of KDCs and admin servers.