### PR TITLE
Add plugins support

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,46 @@ Per realm:
 - ldap\_servers (arrays allowed)
 - ldap\_service\_password\_file
 
+## mit\_krb5::plugins
+
+Resource to add entries to `[plugins]` section.
+
+### Parameters from plugins section
+
+Allowed subsections:
+- ccselect
+- pwqual
+- kadm5\_hook
+- clpreauth
+- kdcpreauth
+- hostrealm
+- localauth
+
+Allowed parameters per subsection:
+
+- disable
+- enable_only
+- module
+
+### Example
+
+The following `plugins` section (used to disable `k5identity`)
+
+```
+[plugins]
+    ccselect = {
+        disable = k5identity
+    }
+```
+
+could be obtained with
+
+```puppet
+::mit_krb5::plugins { 'ccselect':
+    disable => 'k5identity',
+}
+```
+
 # Limitations
 
 Configuration sections other than those listed above are not yet supported.
@@ -342,7 +382,6 @@ This includes:
 - `capaths`
 - `dbdefaults`
 - `login`
-- `plugins`
 
 Stub classes for those sections exist but will throw an error.
 

--- a/manifests/domain_realm.pp
+++ b/manifests/domain_realm.pp
@@ -48,5 +48,10 @@ define mit_krb5::domain_realm(
       order   => "21realm_${realm}_${title}",
       content => template('mit_krb5/domain_realm.erb'),
     }
+    ensure_resource('concat::fragment', 'mit_krb5::domain_realm_trailer', {
+      target  => $mit_krb5::krb5_conf_path,
+      order   => '22domain_realm_trailer',
+      content => "\n",
+    })
   }
 }

--- a/manifests/plugins.pp
+++ b/manifests/plugins.pp
@@ -2,15 +2,108 @@
 #
 # Configure plugins section of krb5.conf
 #
+# === Possible subsections (resource titles)
+#
+# [*ccselect*]
+#   The ccselect subsection controls modules for credential cache selection
+#   within a cache collection.
+#
+# [*pwqual*]
+#   The pwqual subsection controls modules for the password quality interface.
+#
+# [*kadm5_hook*]
+#   The kadm5_hook interface provides plugins with information on
+#   principal creation, modification, password changes and deletion.
+#
+# [*clpreauth*]
+#   The clpreauth interface allows plugin modules to provide
+#   client preauthentication mechanisms.
+#
+# [*kdcpreauth*]
+#   The kdcpreauth interface allows plugin modules to provide
+#   KDC preauthentication mechanisms.
+#
+# [*hostrealm*]
+#   The hostrealm section controls modules for the host-to-realm interface,
+#    which affects the local mapping of hostnames to realm names and
+#    the choice of default realm.
+#
+# [*localauth*]
+#   The localauth section controls modules for the local authorization
+#   interface, which affects the relationship between Kerberos principals
+#   and local system accounts.
+#
+# === Parameters
+#
+# [*disable*]
+#   This tag may have multiple values. If there are values for this tag,
+#   then the named modules will be disabled for the pluggable interface.
+#
+# [*enable_only*]
+#   This tag may have multiple values. If there are values for this tag,
+#   then only the named modules will be enabled for the pluggable interface.
+#
+# [*module*]
+#   This tag may have multiple values. Each value is a string of the form
+#   modulename:pathname, which causes the shared object located at pathname
+#   to be registered as a dynamic module named modulename for the pluggable
+#   interface. If pathname is not an absolute path, it will be treated as
+#   relative to the plugin_base_dir value from [libdefaults].
+#
+# === Examples
+#
+#  mit_krb5::plugins { 'ccselect':
+#    disable        => 'k5identity',
+#  }
+#
+#  mit_krb5::plugins { 'pwqual':
+#    enable_only    => [ 'dict', 'princ' ],
+#  }
+#
 # === Authors
 #
 # Patrick Mooney <patrick.f.mooney@gmail.com>
+# Oliver Freyermuth <freyermuth@physik.uni-bonn.de>
 #
 # === Copyright
 #
 # Copyright 2013 Patrick Mooney.
 # Copyright (c) IN2P3 Computing Centre, IN2P3, CNRS
 #
-class mit_krb5::plugins {
-  fail('PLACEHOLDER: Not yet implemented')
+define mit_krb5::plugins(
+  $disable     = undef,
+  $enable_only = undef,
+  $module      = undef,
+) {
+
+  include ::mit_krb5
+
+  $interfaces = [
+    'ccselect',
+    'pwqual',
+    'kadm5_hook',
+    'clpreauth',
+    'kdcpreauth',
+    'hostrealm',
+    'localauth',
+  ]
+  unless $title in $interfaces {
+    fail("Interface ${title} not supported in plugins section!")
+  }
+
+  ensure_resource('concat::fragment', 'mit_krb5::plugins_header', {
+    target  => $mit_krb5::krb5_conf_path,
+    order   => '40plugins_header',
+    content => "[plugins]\n",
+  })
+  concat::fragment { "mit_krb5::plugins::${title}":
+    target  => $mit_krb5::krb5_conf_path,
+    order   => "41plugins_${title}",
+    content => template('mit_krb5/plugins.erb'),
+  }
+  ensure_resource('concat::fragment', 'mit_krb5::plugins_trailer', {
+    target  => $mit_krb5::krb5_conf_path,
+    order   => '42plugins_trailer',
+    content => "\n",
+  })
 }

--- a/templates/plugins.erb
+++ b/templates/plugins.erb
@@ -1,0 +1,25 @@
+<%- tags = [
+    'disable',
+    'enable_only',
+    'module',
+]
+output = []
+scope_hash = scope.to_hash
+tags.each do |t|
+  if scope_hash.include?(t)
+    value = scope_hash[t]
+    if value.respond_to?('each')
+      # Allow multiple values via array
+      value.flatten! if value.respond_to?('flatten')
+      value.each do |v|
+        output.push("#{t} = #{v}")
+      end
+    elsif not value.empty?
+      output.push("#{t} = #{value}")
+    end
+  end
+end
+-%>
+    <%= @title -%> = {
+        <%= output.join("\n        ") %>
+    }


### PR DESCRIPTION
This implements `mit_krb5::plugins`. 

`mit_krb5::plugins` is converted to a resource and
the code validates titles as being supported plugins.
This allows each plugin subsection to be configured separately.