### PR TITLE
Allow stdlib 9.x - unpin etc_services

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.13.0 <9.0.0"
+      "version_requirement": ">=4.13.0 <10.0.0"
     },
     {
       "name": "puppetlabs/concat",

--- a/metadata.json
+++ b/metadata.json
@@ -10,8 +10,7 @@
       "version_requirement": ">=1.1.0 <10.0.0"
     },
     {
-      "name": "ccin2p3/etc_services",
-      "version_requirement": ">=2.0.0 <3.0.0"
+      "name": "ccin2p3/etc_services"
     }
   ],
   "description": "Install and configure MIT Kerberos v5 (initial version from Patrick Mooney)",


### PR DESCRIPTION
Preparation for upgrade to Puppet 8.x

Allow stdlib up to version 9. Also remove the version pinning between 2 and 3 for etc_services, because this prevents using a higher stdlib version.

A signed commit to make sure the work in #34 gets merged