### PR TITLE
Add puppet8 / data types support 

### DIFF
--- a/manifests/appdefaults.pp
+++ b/manifests/appdefaults.pp
@@ -12,20 +12,31 @@
 # Copyright 2013 Patrick Mooney.
 # Copyright (c) IN2P3 Computing Centre, IN2P3, CNRS
 #
-
-define mit_krb5::appdefaults(
-  $debug                 = '',
-  $ticket_lifetime       = '',
-  $renew_lifetime        = '',
-  $forwardable           = '',
-  $krb4_convert          = '',
-  $ignore_afs            = '',
+# @param debug
+#
+# @param ticket_lifetime
+#
+# @param renew_lifetime
+#
+# @param forwardable
+#
+# @param krb4_convert
+#
+# @param ignore_afs
+#
+define mit_krb5::appdefaults (
+  Optional[String] $debug                      = undef,
+  Optional[String] $ticket_lifetime            = undef,
+  Optional[String] $renew_lifetime             = undef,
+  Optional[Mit_krb5::Bool_or_str] $forwardable = undef,
+  Optional[String] $krb4_convert    = undef,
+  Optional[String] $ignore_afs      = undef,
 ) {
   include mit_krb5
   ensure_resource('concat::fragment', 'mit_krb5::appdefaults_header', {
-    target  => $mit_krb5::krb5_conf_path,
-    order   => '50appdefauls_header',
-    content => "\n[appdefaults]",
+      target  => $mit_krb5::krb5_conf_path,
+      order   => '50appdefauls_header',
+      content => "\n[appdefaults]",
   })
   concat::fragment { "mit_krb5::appdefaults::${title}":
     target  => $mit_krb5::krb5_conf_path,
@@ -33,5 +44,3 @@ define mit_krb5::appdefaults(
     content => template('mit_krb5/appdefaults.erb'),
   }
 }
-
-

--- a/manifests/capaths.pp
+++ b/manifests/capaths.pp
@@ -11,6 +11,6 @@
 # Copyright 2013 Patrick Mooney.
 # Copyright (c) IN2P3 Computing Centre, IN2P3, CNRS
 #
-define mit_krb5::capaths() {
+define mit_krb5::capaths () {
   fail('PLACEHOLDER: Not yet implemented')
 }

--- a/manifests/config/etc_services.pp
+++ b/manifests/config/etc_services.pp
@@ -1,6 +1,5 @@
 #
 class mit_krb5::config::etc_services {
-
   $protocols = {
     'tcp' => 88,
     'udp' => 88,
@@ -8,8 +7,8 @@ class mit_krb5::config::etc_services {
 
   ::etc_services { 'kerberos':
     protocols => $protocols,
-    aliases   => [ 'kerberos5', 'krb5', 'kerberos-sec' ],
-    comment   => 'Kerberos v5'
+    aliases   => ['kerberos5', 'krb5', 'kerberos-sec'],
+    comment   => 'Kerberos v5',
   }
 }
 

--- a/manifests/dbmodules.pp
+++ b/manifests/dbmodules.pp
@@ -84,31 +84,31 @@
 # Copyright 2016 Modestas Vainius.
 # Copyright (c) IN2P3 Computing Centre, IN2P3, CNRS
 #
-define mit_krb5::dbmodules(
-  String $realm               = $title,
-  $database_name              = '',
-  $db_library                 = '',
-  $disable_last_success       = '',
-  $disable_lockout            = '',
-  $ldap_cert_path             = '',
-  $ldap_conns_per_server      = '',
-  $ldap_kadmind_dn            = '',
-  $ldap_kdc_dn                = '',
-  $ldap_kerberos_container_dn = '',
-  $ldap_servers               = '',
-  $ldap_service_password_file = '',
+define mit_krb5::dbmodules (
+  String $realm                                = $title,
+  Optional[Mit_krb5::Bool_or_str] $database_name        = undef,
+  Optional[Mit_krb5::Bool_or_str] $db_library           = undef,
+  Optional[Mit_krb5::Bool_or_str] $disable_last_success = undef,
+  Optional[Mit_krb5::Bool_or_str] $disable_lockout      = undef,
+  Optional[Array[String]] $ldap_cert_path             = undef,
+  Optional[Array[String]] $ldap_conns_per_server      = undef,
+  Optional[Array[String]] $ldap_kadmind_dn            = undef,
+  Optional[Array[String]] $ldap_kdc_dn                = undef,
+  Optional[Array[String]] $ldap_kerberos_container_dn = undef,
+  Optional[Array[String]] $ldap_servers               = undef,
+  Optional[String] $ldap_service_password_file = undef,
 ) {
   include mit_krb5
   ensure_resource('concat::fragment', 'mit_krb5::dbmodules_header', {
-    target  => $mit_krb5::krb5_conf_path,
-    order   => '30dbmodules_header',
-    content => "\n[dbmodules]\n",
+      target  => $mit_krb5::krb5_conf_path,
+      order   => '30dbmodules_header',
+      content => "\n[dbmodules]\n",
   })
   if (! empty($mit_krb5::db_module_dir)) {
     ensure_resource('concat::fragment', 'mit_krb5::dbmodules_db_module_dir', {
-      target  => $mit_krb5::krb5_conf_path,
-      order   => '31dbmodules_db_module_dir',
-      content => "    db_module_dir = ${mit_krb5::db_module_dir}\n",
+        target  => $mit_krb5::krb5_conf_path,
+        order   => '31dbmodules_db_module_dir',
+        content => "    db_module_dir = ${mit_krb5::db_module_dir}\n",
     })
   }
   concat::fragment { "mit_krb5::dbmodules::${realm}":

--- a/manifests/domain_realm.pp
+++ b/manifests/domain_realm.pp
@@ -31,17 +31,17 @@
 # Copyright 2013 Patrick Mooney.
 # Copyright (c) IN2P3 Computing Centre, IN2P3, CNRS
 #
-define mit_krb5::domain_realm(
+define mit_krb5::domain_realm (
   Array[String] $domains,
   String $realm = $title,
 ) {
-  include ::mit_krb5
+  include mit_krb5
 
   if count($domains) > 0 {
     ensure_resource('concat::fragment', 'mit_krb5::domain_realm_header', {
-      target  => $mit_krb5::krb5_conf_path,
-      order   => '20domain_realm_header',
-      content => "[domain_realm]\n",
+        target  => $mit_krb5::krb5_conf_path,
+        order   => '20domain_realm_header',
+        content => "[domain_realm]\n",
     })
     concat::fragment { "mit_krb5::domain_realm::${title}":
       target  => $mit_krb5::krb5_conf_path,
@@ -49,9 +49,9 @@ define mit_krb5::domain_realm(
       content => template('mit_krb5/domain_realm.erb'),
     }
     ensure_resource('concat::fragment', 'mit_krb5::domain_realm_trailer', {
-      target  => $mit_krb5::krb5_conf_path,
-      order   => '22domain_realm_trailer',
-      content => "\n",
+        target  => $mit_krb5::krb5_conf_path,
+        order   => '22domain_realm_trailer',
+        content => "\n",
     })
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -226,6 +226,20 @@
 # [*krb5_conf_mode*]
 #   File mode for krb5.conf.  (Default: 0444)
 #
+# [*alter_etc_services*]
+#
+# [*domain_realms*]
+#
+# [*capaths*]
+#
+# [*appdefaults*]
+#
+# [*realms*]
+#
+# [*dbmodules*]
+#
+# [*krb5_conf_warn*]
+#
 # === Examples
 #
 #  class { 'mit_krb5':
@@ -241,59 +255,59 @@
 # Copyright 2013 Patrick Mooney.
 # Copyright (c) IN2P3 Computing Centre, IN2P3, CNRS
 #
-class mit_krb5(
-  String $default_realm                = '',
-  String $default_keytab_name          = '',
-  $default_tgs_enctypes                = [],
-  $default_tkt_enctypes                = [],
-  String $default_ccache_name          = '',
-  $permitted_enctypes                  = [],
-  $allow_weak_crypto                   = '',
-  String $clockskew                    = '',
-  $ignore_acceptor_hostname            = '',
-  $k5login_authoritative               = '',
-  String $k5login_directory            = '',
-  String $kdc_timesync                 = '',
-  String $kdc_req_checksum_type        = '',
-  String $ap_req_checksum_type         = '',
-  String $safe_checksum_type           = '',
-  String $preferred_preauth_types      = '',
-  String $ccache_type                  = '',
-  $canonicalize                        = '',
-  $dns_canonicalize_hostname           = '',
-  $dns_lookup_kdc                      = '',
-  $dns_lookup_realm                    = '',
-  $dns_fallback                        = '',
-  String $realm_try_domains            = '',
-  $extra_addresses                     = [],
-  String $udp_preference_limit         = '',
-  $verify_ap_req_nofail                = '',
-  String $ticket_lifetime              = '',
-  String $renew_lifetime               = '',
-  $noaddresses                         = '',
-  $forwardable                         = '',
-  $proxiable                           = '',
-  $rdns                                = '',
-  $pkinit_anchors                      = '',
-  $spake_preauth_groups                = '',
-  String $plugin_base_dir              = '',
-  $include                             = '',
-  $includedir                          = '',
-  $module                              = '',
-  String $db_module_dir                = '',
-  Stdlib::Absolutepath $krb5_conf_path = '/etc/krb5.conf',
-  String $krb5_conf_owner              = 'root',
-  String $krb5_conf_group              = 'root',
-  Stdlib::Filemode $krb5_conf_mode     = '0444',
-  Boolean $alter_etc_services          = false,
-  Boolean $krb5_conf_warn              = true,
-  Hash $domain_realms                  = {},
-  Hash $capaths                        = {},
-  Hash $appdefaults                    = {},
-  Hash $realms                         = {},
-  Hash $dbmodules                      = {},
-  String[1] $krb5_conf_d_path          = '/etc/krb5.conf.d',
-  Boolean $krb5_conf_d_purge           = false,
+class mit_krb5 (
+  Optional[String] $default_realm               = undef,
+  Optional[String] $default_keytab_name         = undef,
+  Array $default_tgs_enctypes                   = [],
+  Array $default_tkt_enctypes                   = [],
+  Optional[String] $default_ccache_name         = undef,
+  Array $permitted_enctypes                     = [],
+  Optional[Boolean] $allow_weak_crypto          = undef,
+  Optional[String] $clockskew                   = undef,
+  Optional[String] $ignore_acceptor_hostname    = undef,
+  Optional[String] $k5login_authoritative       = undef,
+  Optional[String] $k5login_directory           = undef,
+  Optional[String] $kdc_timesync                = undef,
+  Optional[String] $kdc_req_checksum_type       = undef,
+  Optional[String] $ap_req_checksum_type        = undef,
+  Optional[String] $safe_checksum_type          = undef,
+  Optional[String] $preferred_preauth_types     = undef,
+  Optional[String] $ccache_type                 = undef,
+  Optional[String] $canonicalize                = undef,
+  Optional[Boolean] $dns_canonicalize_hostname  = undef,
+  Optional[Boolean] $dns_lookup_kdc             = undef,
+  Optional[Boolean] $dns_lookup_realm           = undef,
+  Optional[Boolean] $dns_fallback               = undef,
+  Optional[String] $realm_try_domains           = undef,
+  Array $extra_addresses                        = [],
+  Optional[String] $udp_preference_limit        = undef,
+  Optional[Boolean] $verify_ap_req_nofail       = undef,
+  Optional[String] $ticket_lifetime             = undef,
+  Optional[String] $renew_lifetime              = undef,
+  Optional[Mit_krb5::Bool_or_str] $noaddresses  = undef,
+  Optional[Mit_krb5::Bool_or_str] $forwardable  = undef,
+  Optional[Mit_krb5::Bool_or_str] $proxiable    = undef,
+  Optional[Mit_krb5::Bool_or_str] $rdns         = undef,
+  Optional[Array[String]] $pkinit_anchors       = undef,
+  Optional[Array[String]] $spake_preauth_groups = undef,
+  Optional[Array[String]] $plugin_base_dir      = undef,
+  Optional[Array[String]] $include              = undef,
+  Optional[Array[String]] $includedir           = undef,
+  Optional[Array[String]] $module               = undef,
+  Optional[String] $db_module_dir               = undef,
+  String $krb5_conf_path                        = '/etc/krb5.conf',
+  String $krb5_conf_d_path                      = '/etc/krb5.conf.d',
+  String $krb5_conf_owner                       = 'root',
+  String $krb5_conf_group                       = 'root',
+  String $krb5_conf_mode                        = '0444',
+  Boolean $alter_etc_services                   = false,
+  Boolean $krb5_conf_warn                       = true,
+  Hash $domain_realms                           = {},
+  Hash $capaths                                 = {},
+  Hash $appdefaults                             = {},
+  Hash $realms                                  = {},
+  Hash $dbmodules                               = {},
+  Boolean $krb5_conf_d_purge                    = false,
 ) {
   # SECTION: Parameter validation {
   # Boolean-type parameters are not type-validated at this time.
@@ -307,13 +321,11 @@ class mit_krb5(
   # END Parameter validation }
 
   # SECTION: Resource creation {
-  anchor { 'mit_krb5::begin': }
-
-  class { '::mit_krb5::install': }
+  contain 'mit_krb5::install'
 
   if ($alter_etc_services == true) {
-    class { '::mit_krb5::config::etc_services':
-      require => Class['::mit_krb5::install']
+    class { 'mit_krb5::config::etc_services':
+      require => Class['mit_krb5::install'],
     }
   }
 
@@ -321,7 +333,7 @@ class mit_krb5(
     owner => $krb5_conf_owner,
     group => $krb5_conf_group,
     mode  => $krb5_conf_mode,
-    warn  => $krb5_conf_warn
+    warn  => $krb5_conf_warn,
   }
   concat::fragment { 'mit_krb5::header':
     target  => $krb5_conf_path,
@@ -355,9 +367,8 @@ class mit_krb5(
   # END Resource creation }
 
   # SECTION: Resource ordering {
-  Anchor['mit_krb5::begin']
-  -> Class['mit_krb5::install']
+  contain 'mit_krb5::install'
+  Class['mit_krb5::install']
   -> Concat[$krb5_conf_path]
-  -> Anchor['mit_krb5::end']
   # END Resource ordering }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,7 +11,11 @@
 # Copyright 2013 Patrick Mooney.
 # Copyright (c) IN2P3 Computing Centre, IN2P3, CNRS
 #
-class mit_krb5::install($packages = undef) {
+# @param packages
+#
+class mit_krb5::install (
+  Optional[Variant[String, Array[String]]] $packages = undef,
+) {
   if $packages {
     if is_array($packages) {
       $install = flatten($packages)

--- a/manifests/logging.pp
+++ b/manifests/logging.pp
@@ -40,14 +40,13 @@
 # Copyright 2013 Patrick Mooney.
 # Copyright (c) IN2P3 Computing Centre, IN2P3, CNRS
 #
-class mit_krb5::logging(
-  $default      = '',
-  $admin_server = '',
-  $kdc          = '',
-  $defaults     = '',
+class mit_krb5::logging (
+  Optional[Array[String]] $default      = undef,
+  Optional[Array[String]] $admin_server = undef,
+  Optional[Array[String]] $kdc          = undef,
+  Optional[String] $defaults            = undef,
 ) {
-
-  include ::mit_krb5
+  include mit_krb5
 
   concat::fragment { 'mit_krb5::logging':
     target  => $mit_krb5::krb5_conf_path,

--- a/manifests/plugins.pp
+++ b/manifests/plugins.pp
@@ -2,37 +2,6 @@
 #
 # Configure plugins section of krb5.conf
 #
-# === Possible subsections (resource titles)
-#
-# [*ccselect*]
-#   The ccselect subsection controls modules for credential cache selection
-#   within a cache collection.
-#
-# [*pwqual*]
-#   The pwqual subsection controls modules for the password quality interface.
-#
-# [*kadm5_hook*]
-#   The kadm5_hook interface provides plugins with information on
-#   principal creation, modification, password changes and deletion.
-#
-# [*clpreauth*]
-#   The clpreauth interface allows plugin modules to provide
-#   client preauthentication mechanisms.
-#
-# [*kdcpreauth*]
-#   The kdcpreauth interface allows plugin modules to provide
-#   KDC preauthentication mechanisms.
-#
-# [*hostrealm*]
-#   The hostrealm section controls modules for the host-to-realm interface,
-#    which affects the local mapping of hostnames to realm names and
-#    the choice of default realm.
-#
-# [*localauth*]
-#   The localauth section controls modules for the local authorization
-#   interface, which affects the relationship between Kerberos principals
-#   and local system accounts.
-#
 # === Parameters
 #
 # [*disable*]
@@ -70,13 +39,12 @@
 # Copyright 2013 Patrick Mooney.
 # Copyright (c) IN2P3 Computing Centre, IN2P3, CNRS
 #
-define mit_krb5::plugins(
-  $disable     = undef,
-  $enable_only = undef,
-  $module      = undef,
+define mit_krb5::plugins (
+  Optional[Array[String]] $disable     = undef,
+  Optional[Array[String]] $enable_only = undef,
+  Optional[Array[String]] $module      = undef,
 ) {
-
-  include ::mit_krb5
+  include mit_krb5
 
   $interfaces = [
     'ccselect',
@@ -93,9 +61,9 @@ define mit_krb5::plugins(
   }
 
   ensure_resource('concat::fragment', 'mit_krb5::plugins_header', {
-    target  => $mit_krb5::krb5_conf_path,
-    order   => '40plugins_header',
-    content => "[plugins]\n",
+      target  => $mit_krb5::krb5_conf_path,
+      order   => '40plugins_header',
+      content => "[plugins]\n",
   })
   concat::fragment { "mit_krb5::plugins::${title}":
     target  => $mit_krb5::krb5_conf_path,
@@ -103,8 +71,8 @@ define mit_krb5::plugins(
     content => template('mit_krb5/plugins.erb'),
   }
   ensure_resource('concat::fragment', 'mit_krb5::plugins_trailer', {
-    target  => $mit_krb5::krb5_conf_path,
-    order   => '42plugins_trailer',
-    content => "\n",
+      target  => $mit_krb5::krb5_conf_path,
+      order   => '42plugins_trailer',
+      content => "\n",
   })
 }

--- a/manifests/realm.pp
+++ b/manifests/realm.pp
@@ -60,7 +60,7 @@
 #		 TEST4 = host2
 #	     }
 #        }
-#                                                   
+#
 # [*auth_to_local_names*]
 #   This subsection allows you to set explicit mappings from principal names to
 #   local user names.  The tag is the mapping name, and the value is the
@@ -115,30 +115,29 @@
 # Copyright 2013 Patrick Mooney.
 # Copyright (c) IN2P3 Computing Centre, IN2P3, CNRS
 #
-define mit_krb5::realm(
-  $kdc                    = '',
-  $master_kdc             = '',
-  $admin_server           = '',
-  $database_module        = '',
-  $default_domain         = '',
-  $v4_instance_convert    = '',
-  $v4_realm               = '',
-  $auth_to_local_names    = '',
-  $auth_to_local          = '',
-  $kpasswd_server         = '',
-  $v4_realm_convert       = '',
-  $pkinit_anchors         = '',
-  $pkinit_pool            = '',
-  Boolean $rotate_servers = false,
-  $http_anchors           = '',
+define mit_krb5::realm (
+  Optional[Array[String]] $kdc        = undef,
+  Optional[Array[String]] $master_kdc = undef,
+  Optional[String] $admin_server        = undef,
+  Optional[String] $database_module     = undef,
+  Optional[String] $default_domain      = undef,
+  Optional[String] $v4_instance_convert = undef,
+  Optional[String] $v4_realm            = undef,
+  Optional[String] $auth_to_local_names = undef,
+  Optional[Array[String]] $auth_to_local       = undef,
+  Optional[String] $kpasswd_server      = undef,
+  Array $v4_realm_convert               = [],
+  Optional[String] $pkinit_anchors      = undef,
+  Optional[String] $pkinit_pool         = undef,
+  Boolean $rotate_servers               = false,
+  Optional[String] $http_anchors        = undef,
 ) {
-
-  include ::mit_krb5
+  include mit_krb5
 
   ensure_resource('concat::fragment', 'mit_krb5::realm_header', {
-    target  => $mit_krb5::krb5_conf_path,
-    order   => '10realm_header',
-    content => "[realms]\n",
+      target  => $mit_krb5::krb5_conf_path,
+      order   => '10realm_header',
+      content => "[realms]\n",
   })
   concat::fragment { "mit_krb5::realm::${title}":
     target  => $mit_krb5::krb5_conf_path,

--- a/metadata.json
+++ b/metadata.json
@@ -56,7 +56,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 8.0.0"
+      "version_requirement": ">= 4.7.0 < 9.0.0"
     }
   ],
   "source": "https://github.com/ccin2p3/puppet-mit_krb5.git",

--- a/types/bool_or_str.pp
+++ b/types/bool_or_str.pp
@@ -1,0 +1,1 @@
+type Mit_krb5::Bool_or_str = Variant[Boolean, Enum['true', 'false']]


### PR DESCRIPTION
This is based on https://github.com/ccin2p3/puppet-mit_krb5/pull/38 but fixing the init.pp. Two variables where not defined in there leading to puppet not running.
We have this version working in production.

I've uploaded this version here, so it can be used: https://forge.puppet.com/modules/tobipeterg/mit_krb5/readme